### PR TITLE
octoprint_rtsp/streamor.py: Changed -timeout argument to -stimeout

### DIFF
--- a/octoprint_rtsp/streamor.py
+++ b/octoprint_rtsp/streamor.py
@@ -145,7 +145,7 @@ class Streamor:
             '-nostdin',
             '-rtsp_transport', 'tcp',
             '-rtsp_flags', 'prefer_tcp',
-            '-timeout', '5000000',
+            '-stimeout', '5000000',
             '-fflags', 'nobuffer',
             '-i', self.url,
             '-an',


### PR DESCRIPTION
Commit: octoprint_rtsp/streamor.py: Changed -timeout argument to -stimeout in the FFmpeg command execution list.

Resolves an issue where the plugin's FFmpeg subprocess immediately crashes when attempting to capture an RTSP stream, specifically in Debian/Ubuntu-based Docker environments (like the official octoprint/octoprint image).

To apply a timeout to an RTSP client connection (pulling a stream from a camera), the correct FFmpeg flag is -stimeout (Socket Timeout), measured in microseconds. Changing -timeout to -stimeout allows FFmpeg to correctly initialize as a client, connect to the camera, and successfully pipe the MJPEG stream back to OctoPrint.

Tested with OctoPrint running in a container on "Ubuntu 24.04.4 LTS".